### PR TITLE
Expose UDP port on the instance so that apps in other docker containers can send custom metrics.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     image: datadog/docker-dd-agent:latest
     environment:
      - API_KEY
+    ports:
+      - 8125/udp
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /proc/:/host/proc


### PR DESCRIPTION
Running this on one of our racks. 

Other apps in containers on the same instance can send datagrams to port 8125 on the gateway, which is what the official DataDog python client does:

https://github.com/DataDog/datadogpy/blob/master/datadog/dogstatsd/route.py#L15

Also see a very simple example in ruby just using shell scripts and raw UDP datagrams: https://github.com/mfine/simple-monitor/blob/master/api.rb#L4