### PR TITLE
Enable for Datadog APM, set volumes to recommended settings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,14 +4,15 @@ services:
     image: datadog/docker-dd-agent:latest
     environment:
      - API_KEY
-    ports:
-      - 8125/udp
+     - DD_APM_ENABLED=true
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /proc/:/host/proc
       - /cgroup/:/host/sys/fs/cgroup
     ports:
       - 8125/udp
+      - 8126/tcp
     privileged: true
     labels:
       - convox.agent=true
+      - convox.balancer=false


### PR DESCRIPTION
- Datadog APM ready configuration
- Switched mounted volumes to recommended settings as per the latest version of the Datadog Agent doc
- Removed extra ports statement