### PR TITLE
update cgroup path for amazon linux 2

### DIFF
--- a/convox.yml
+++ b/convox.yml
@@ -13,6 +13,6 @@ services:
       cpu: 128
       memory: 128
     volumes:
-      - /cgroup/:/host/sys/fs/cgroup/
+      - /sys/fs/cgroup/:/host/sys/fs/cgroup/
       - /proc/:/host/proc/
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
After Convox updated to use Amazon Linux 2, the path to cgroups on the host has changed and needs to be updated for the datadog agent to be able to read it.

Running the current master datadog agent & an updated rack, `convox logs` shows errors such as:
```
[ AGENT ] 2019-01-02 23:28:06 UTC | ERROR | (cgroup_detect.go:53 in cgroupFilePath) | Missing target memory from mounts
[ AGENT ] 2019-01-02 23:28:06 UTC | ERROR | (cgroup_detect.go:53 in cgroupFilePath) | Missing target memory from mounts
[ AGENT ] 2019-01-02 23:28:06 UTC | ERROR | (cgroup_detect.go:53 in cgroupFilePath) | Missing target memory from mounts
```

See also: https://github.com/DataDog/datadog-agent/issues/2651

